### PR TITLE
Allow setting owner references

### DIFF
--- a/config/eventing-istio/roles/controller-clusterroles.yaml
+++ b/config/eventing-istio/roles/controller-clusterroles.yaml
@@ -31,6 +31,18 @@ rules:
       - "watch"
 
   - apiGroups:
+      - ""
+    resources:
+      - "services/finalizers"
+    verbs:
+      - "create"
+      - "update"
+      - "delete"
+      - "get"
+      - "list"
+      - "watch"
+
+  - apiGroups:
       - "networking.istio.io"
     resources:
       - "destinationrules"


### PR DESCRIPTION
In OpenShift, I'm getting permission errors due to the fact that the controller is not allowed to finalize services.

This doesn't happen in Kubernetes, however, it might happen on some Kube clusters depending on their configurations, so I'm adding permissions to set finalizers to the controller here for everyone.