### PR TITLE
Fix `REPO_ROOT_DIR` env override in e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 
-REPO_ROOT_DIR=$(dirname $(realpath $0))/..
+repo_root_dir=$(dirname $(realpath $0))/..
 
-echo "$REPO_ROOT_DIR"
+echo "$repo_root_dir"
 
 export SKIP_INITIALIZE=${SKIP_INITIALIZE:-false}
 export SYSTEM_NAMESPACE=${SYSTEM_NAMESPACE:-"knative-eventing"}
 export ISTIO_NAMESPACE=${ISTIO_NAMESPACE:-"istio-system"}
-export KAFKA_BROKER_TEMPLATES=${KAFKA_BROKER_TEMPLATES:-"${REPO_ROOT_DIR}/test/e2e/templates/kafka-broker"}
-export KAFKA_NAMESPACED_BROKER_TEMPLATES=${KAFKA_BROKER_TEMPLATES:-"${REPO_ROOT_DIR}/test/e2e/templates/kafka-namespaced-broker"}
+export KAFKA_BROKER_TEMPLATES=${KAFKA_BROKER_TEMPLATES:-"${repo_root_dir}/test/e2e/templates/kafka-broker"}
+export KAFKA_NAMESPACED_BROKER_TEMPLATES=${KAFKA_BROKER_TEMPLATES:-"${repo_root_dir}/test/e2e/templates/kafka-namespaced-broker"}
 
-source "${REPO_ROOT_DIR}"/vendor/knative.dev/hack/e2e-tests.sh
+source "${repo_root_dir}"/vendor/knative.dev/hack/e2e-tests.sh
 
 function knative_setup() {
   git submodule update --init --recursive
-  "${REPO_ROOT_DIR}"/hack/install-dependencies.sh || return $?
-  "${REPO_ROOT_DIR}"/hack/install.sh || return $?
+  "${repo_root_dir}"/hack/install-dependencies.sh || return $?
+  "${repo_root_dir}"/hack/install.sh || return $?
 
   wait_until_pods_running "knative-eventing" || return $?
 }
 
 function run_eventing_core_tests() {
-  pushd "${REPO_ROOT_DIR}"/third_party/eventing || return $?
+  pushd "${repo_root_dir}"/third_party/eventing || return $?
 
   BROKER_TEMPLATES="${KAFKA_BROKER_TEMPLATES}" go_test_e2e \
     -timeout=1h \
@@ -80,7 +80,7 @@ function run_eventing_core_tests() {
 }
 
 function run_eventing_kafka_broker_tests() {
-  pushd "${REPO_ROOT_DIR}"/third_party/eventing-kafka-broker || return $?
+  pushd "${repo_root_dir}"/third_party/eventing-kafka-broker || return $?
 
   BROKER_TEMPLATES="${KAFKA_BROKER_TEMPLATES}" BROKER_CLASS="Kafka" go_test_e2e \
     -timeout=1h \


### PR DESCRIPTION
Currently the release script fails, as the `KO_DOCKER_REPO` env is invalid:
```
- KO_DOCKER_REPO is gcr.io/knative-boskos-03/..-e2e-img/1491
```

This env is set via:
https://github.com/knative-sandbox/eventing-istio/blob/ba1e57aa39a6db5802236b8eb1308b92aac111dd/vendor/knative.dev/hack/e2e-tests.sh#L75-L77

The `REPO_NAME` env is set via
https://github.com/knative-sandbox/eventing-istio/blob/ba1e57aa39a6db5802236b8eb1308b92aac111dd/vendor/knative.dev/hack/library.sh#L46-L55

As we override the `REPO_ROOT_DIR` env in the e2e-common.sh (which then has the `..` suffix), `__resolveRepoName $REPO_ROOT_DIR` resolves to `..`:

https://github.com/knative-sandbox/eventing-istio/blob/ba1e57aa39a6db5802236b8eb1308b92aac111dd/test/e2e-common.sh#L3

```
$ source release.sh
$ echo $REPO_NAME
eventing-istio
$ __resolveRepoName
eventing-istio
$ __resolveRepoName /home/prow/go/src/knative.dev/eventing-istio/test/..
..
```

This PR addresses it and renames the `REPO_ROOT_DIR` var in `e2e-common.sh`.