### PR TITLE
Use correct path to `hack/build-from-source.sh`

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -29,7 +29,7 @@ function fail() {
 }
 
 function generate_artifacts() {
-  "$(dirname $0)"/hack/build-from-source.sh || return $?
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/build-from-source.sh || return $?
 }
 
 function update_release_labels() {


### PR DESCRIPTION
Running in `./hack/release.sh: line 32: ./hack/hack/build-from-source.sh: No such file or directory` in CI

/assign @pierDipi 