### PR TITLE
Fix setting readonly `TAG` variable

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -33,11 +33,11 @@ function generate_artifacts() {
 }
 
 function update_release_labels() {
-  TAG=${TAG:-$(git rev-parse HEAD)}
+  release_tag=${TAG:-$(git rev-parse HEAD)}
   
-  echo "Updating release labels to app.kubernetes.io/version: \"${TAG}\""
+  echo "Updating release labels to app.kubernetes.io/version: \"${release_tag}\""
 
-  sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG}\"|" -i ${EVENTING_ISTIO_ARTIFACT}
+  sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${release_tag}\"|" -i ${EVENTING_ISTIO_ARTIFACT}
 }
 
 function build_release() {


### PR DESCRIPTION
This PR fixes the setting of the readonly TAG variable: 

`./hack/release.sh: line 36: TAG: readonly variable`

https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing-istio_main_periodic/1679115350215495680